### PR TITLE
Adjust how altair is reading large data files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,4 @@ gunicorn
 altair
 dash==1.18.1
 dash_bootstrap_components
-dash_html_components 
-dash_core_components
 plotly==4.14.3
-altair_data_server

--- a/src/app.py
+++ b/src/app.py
@@ -53,8 +53,8 @@ def import_data():
     pd.Dataframe
         dataframe containing all data from the processed import file
     """
-    # Handle large data sets without embedding them in the notebook
-    alt.data_transformers.enable("data_server")
+    # Disable max rows for data sent to altair plots
+    alt.data_transformers.disable_max_rows()
     
     path = "data/processed/DSCI532-CDN-CRIME-DATA.tsv"
     data = pd.read_csv(path, sep="\t", encoding="ISO-8859-1")
@@ -204,7 +204,7 @@ def set_dropdown_values(__, geo_level):
 
 if __name__ == '__main__':
     
-    # Allow for larger altair plots
-    alt.data_transformers.enable("data_server")
+    # Disable max rows for data sent to altair plots
+    alt.data_transformers.disable_max_rows()
     
     app.run_server(debug=True)


### PR DESCRIPTION
- Remove data servers (not functional on heroku)
- Remove 'max_rows' argument for altair plots